### PR TITLE
Feature11 - Data Seeding & Saving to Database

### DIFF
--- a/GameStore_Backend_API/DTOs/CreateGameDTO.cs
+++ b/GameStore_Backend_API/DTOs/CreateGameDTO.cs
@@ -5,7 +5,7 @@ namespace GameStore_Backend_API.DTOs;
 public record class CreateGameDTO
 (
     [Required][StringLength(50)] string Name,
-    [Required][StringLength(20)] string Genre,
+                                 int GenreID,
     [Range(1, 100)]              decimal Price,
     DateOnly                     ReleaseDate
 );

--- a/GameStore_Backend_API/Data/GameStoreContext.cs
+++ b/GameStore_Backend_API/Data/GameStoreContext.cs
@@ -7,4 +7,14 @@ public class GameStoreContext(DbContextOptions<GameStoreContext> options) : DbCo
 {
     public DbSet<Game> Games => Set<Game>();
     public DbSet<Genre> Genres => Set<Genre>();
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<Genre>().HasData(
+            new{ID = 1, Name = "Action"},
+            new{ID = 2, Name = "RPG"},
+            new{ID = 3, Name = "Sports"},
+            new{ID = 4, Name = "Casual"},
+            new{ID = 5, Name = "Racing"}
+        );
+    }
 }

--- a/GameStore_Backend_API/Data/Migrations/20240510105804_SeedGenres.Designer.cs
+++ b/GameStore_Backend_API/Data/Migrations/20240510105804_SeedGenres.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using GameStore_Backend_API.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace GameStore_Backend_API.Data.Migrations
 {
     [DbContext(typeof(GameStoreContext))]
-    partial class GameStoreContextModelSnapshot : ModelSnapshot
+    [Migration("20240510105804_SeedGenres")]
+    partial class SeedGenres
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "8.0.4");

--- a/GameStore_Backend_API/Data/Migrations/20240510105804_SeedGenres.cs
+++ b/GameStore_Backend_API/Data/Migrations/20240510105804_SeedGenres.cs
@@ -1,0 +1,57 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+#pragma warning disable CA1814 // Prefer jagged arrays over multidimensional
+
+namespace GameStore_Backend_API.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class SeedGenres : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.InsertData(
+                table: "Genres",
+                columns: new[] { "ID", "Name" },
+                values: new object[,]
+                {
+                    { 1, "Action" },
+                    { 2, "RPG" },
+                    { 3, "Sports" },
+                    { 4, "Casual" },
+                    { 5, "Racing" }
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DeleteData(
+                table: "Genres",
+                keyColumn: "ID",
+                keyValue: 1);
+
+            migrationBuilder.DeleteData(
+                table: "Genres",
+                keyColumn: "ID",
+                keyValue: 2);
+
+            migrationBuilder.DeleteData(
+                table: "Genres",
+                keyColumn: "ID",
+                keyValue: 3);
+
+            migrationBuilder.DeleteData(
+                table: "Genres",
+                keyColumn: "ID",
+                keyValue: 4);
+
+            migrationBuilder.DeleteData(
+                table: "Genres",
+                keyColumn: "ID",
+                keyValue: 5);
+        }
+    }
+}

--- a/GameStore_Backend_API/games.http
+++ b/GameStore_Backend_API/games.http
@@ -9,7 +9,7 @@ Content-Type: application/json
 
 {
     "name": "Forza Horizon 4",
-    "genre": "Racing",
+    "genreID": 5,
     "price": 99.99,
     "releaseDate": "2018-09-28"
 }


### PR DESCRIPTION
- Add default genre presets to the database via data seeding
- Update C# data class (GameStoreContext) which now contains a callback to populate pre-defined genres upon successful execution of migration process
- Update POST endpoint which would now create new game & insert it into the database
- Intermediate C# class ("SeedGenres") is automatically generated as a result of successful execution of migration process for data seeding