### PR TITLE
Feature12 - Entity DTO Mapping & CRUD operations on Database

### DIFF
--- a/GameStore_Backend_API/DTOs/GameDetailsDTO.cs
+++ b/GameStore_Backend_API/DTOs/GameDetailsDTO.cs
@@ -1,0 +1,8 @@
+﻿namespace GameStore_Backend_API.DTOs;
+
+public record class GameDetailsDTO(
+    int ID,
+    string Name,
+    int GenreID,
+    decimal Price,
+    DateOnly ReleaseDate);

--- a/GameStore_Backend_API/DTOs/GameSummaryDTO.cs
+++ b/GameStore_Backend_API/DTOs/GameSummaryDTO.cs
@@ -1,6 +1,6 @@
 ﻿namespace GameStore_Backend_API.DTOs;
 
-public record class GameDTO(
+public record class GameSummaryDTO(
     int ID,
     string Name,
     string Genre,

--- a/GameStore_Backend_API/DTOs/UpdateGameDTO.cs
+++ b/GameStore_Backend_API/DTOs/UpdateGameDTO.cs
@@ -5,7 +5,7 @@ namespace GameStore_Backend_API.DTOs;
 public record class UpdateGameDTO
 (
     [Required][StringLength(50)] string Name,
-    [Required][StringLength(20)] string Genre,
+                                 int GenreID,
     [Range(1, 100)]              decimal Price,
     DateOnly                     ReleaseDate
 );

--- a/GameStore_Backend_API/Mapping/GameMapping.cs
+++ b/GameStore_Backend_API/Mapping/GameMapping.cs
@@ -1,0 +1,52 @@
+﻿using GameStore_Backend_API.DTOs;
+using GameStore_Backend_API.Entities;
+
+namespace GameStore_Backend_API.Mapping;
+
+public static class GameMapping
+{
+    public static Game ToEntity(this CreateGameDTO game)
+    {
+        return new Game()
+        {
+            Name = game.Name,
+            GenreID = game.GenreID,
+            Price = game.Price,
+            ReleaseDate = game.ReleaseDate
+        };
+    }
+
+    public static Game ToEntity(this UpdateGameDTO game, int id)
+    {
+        return new Game()
+        {
+            ID = id,
+            Name = game.Name,
+            GenreID = game.GenreID,
+            Price = game.Price,
+            ReleaseDate = game.ReleaseDate
+        };
+    }
+
+    public static GameSummaryDTO ToGameSummaryDTO(this Game game)
+    {
+        return new(
+            game.ID,
+            game.Name,
+            game.Genre!.Name,
+            game.Price,
+            game.ReleaseDate
+        );
+    }
+
+    public static GameDetailsDTO ToGameDetailsDTO(this Game game)
+    {
+        return new(
+            game.ID,
+            game.Name,
+            game.GenreID,
+            game.Price,
+            game.ReleaseDate
+        );
+    }
+}

--- a/GameStore_Backend_API/games.http
+++ b/GameStore_Backend_API/games.http
@@ -20,7 +20,7 @@ Content-Type: application/json
 
 {
     "name": "Street Fighter II Turbo",
-    "genre": "Action",
+    "genreID": 1,
     "price": 9.99,
     "releaseDate": "1991-02-01"
 }


### PR DESCRIPTION
- Add new C# extension class ("GameMapping") which handles mapping Entities to DTOs & vice versa
- Add new DTO ("GameDetailsDTO") that serves to be a record representing a game item with genre as an ID & NOT string
- Rename "GameDTO" to "GameSummaryDTO"
- Update DTO ("UpdateGameDTO") where genre is represented as an ID & NOT string
- Update endpoints (GET, POST, PUT, DELETE) which are now linked to a database instead of local collection
- We can now query, update & delete entities from database using updated endpoints